### PR TITLE
Change time difference assert from > to >= 0

### DIFF
--- a/autotime.py
+++ b/autotime.py
@@ -22,7 +22,7 @@ class LineWatcher(object):
     def stop(self):
         if self.start_time:
             diff = time.time() - self.start_time
-            assert diff > 0
+            assert diff >= 0
             print('time: %s' % format_delta(diff))
 
 timer = LineWatcher()


### PR DESCRIPTION
diff == 0 occurs on when executing trivial code in a cell. Updating the assert to include this case. The notebook outputs "time: 0 ns" rather than an AssertionError.

Thanks for demoing your extension at PyData - it's a brilliant idea.
