### PR TITLE
Bug fix: fast commands fail the assert

### DIFF
--- a/autotime.py
+++ b/autotime.py
@@ -22,7 +22,7 @@ class LineWatcher(object):
     def stop(self):
         if self.start_time:
             diff = time.time() - self.start_time
-            assert diff > 0
+            assert diff >= 0
             print('time: %s' % format_delta(diff))
 
 timer = LineWatcher()


### PR DESCRIPTION
Example:

In [3]:x=1
## Error in callback <bound method LineWatcher.stop of <autotime.LineWatcher object at 0x0000000004445F28>> (for post_run_cell):

AssertionError                            Traceback (most recent call last)
C:\Users\mbz.ipython\extensions\autotime.py in stop(self)
     23         if self.start_time:
     24             diff = time.time() - self.start_time
---> 25             assert diff > 0
     26             print('time: %s' % format_delta(diff))
     27 

AssertionError:
