### PR TITLE
Create MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include LICENSE
+include README.md


### PR DESCRIPTION
Could you please add the license to MANIFEST.in so that it will be included in sdists and other packages? This came up during packaging of ipython-autotime in [conda-forge](https://conda-forge.github.io/).
