### PR TITLE
Allow time to equal zero

### DIFF
--- a/autotime.py
+++ b/autotime.py
@@ -22,7 +22,7 @@ class LineWatcher(object):
     def stop(self):
         if self.start_time:
             diff = time.time() - self.start_time
-            assert diff > 0
+            assert diff >= 0
             print('time: %s' % format_delta(diff))
 
 timer = LineWatcher()


### PR DESCRIPTION
On machines with low-res clocks, cells that run really quickly may have a runtime of zero which causes AssertionError to raise incorrectly. Protect only against negative times instead.
