### PR TITLE
Use time.monotonic()

### DIFF
--- a/autotime/__init__.py
+++ b/autotime/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import print_function
 
-import time
+from time import monotonic
 
 from IPython.core.magics.execution import _format_time as format_delta
 
@@ -13,26 +13,21 @@ class LineWatcher(object):
     -----
     * Register the `start` and `stop` methods with the IPython events API.
     """
-
-    def __init__(self):
-        self.start_time = 0.0
+    __slots__ = ['start_time']
 
     def start(self):
-        self.start_time = time.time()
+        self.start_time = monotonic()
 
     def stop(self):
-        stop_time = time.time()
-
-        if self.start_time:
-            diff = stop_time - self.start_time
-            assert diff >= 0
-            print('time: {}'.format(format_delta(diff)))
+        delta = monotonic() - self.start_time
+        print('time: {}'.format(format_delta(delta)))
 
 
 timer = LineWatcher()
 
 
 def load_ipython_extension(ip):
+    timer.start()
     ip.events.register('pre_run_cell', timer.start)
     ip.events.register('post_run_cell', timer.stop)
 

--- a/autotime/__init__.py
+++ b/autotime/__init__.py
@@ -1,6 +1,9 @@
 from __future__ import print_function
 
-from time import monotonic
+try:
+    from time import monotonic
+except ImportError:
+    from monotonic import monotonic
 
 from IPython.core.magics.execution import _format_time as format_delta
 

--- a/autotime/__init__.py
+++ b/autotime/__init__.py
@@ -23,7 +23,7 @@ class LineWatcher(object):
 
     def stop(self):
         delta = monotonic() - self.start_time
-        print('time: {}'.format(format_delta(delta)))
+        print(u'time: {}'.format(format_delta(delta)))
 
 
 timer = LineWatcher()

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     description='Time everything in IPython',
     long_description=long_description,
     license='Apache',
-    install_requires=['ipython'],
+    install_requires=['ipython', 'monotonic ; python_version < "3.3"'],
     classifiers=[
         'Environment :: Console',
         'Intended Audience :: Developers',


### PR DESCRIPTION
Hi!

Just some small improvements I spotted while inspecting this already beautifully lean lib.
Fixes #10, closes #13

How does your release flow work? Do you merge to default branch, git tag, and upload to Pypi from there? As an alternative to your `versioneer` setup, you could use `setuptools_scm`, designed for this specific purpose. See e.g. https://github.com/john-kurkowski/tldextract/pull/187

### Description

time.monotonic() relates to the real time spent inside the main thread, and can not be altered externally by e.g.
- ntp system time synchronisation (frequent, small impact)
- automatic time zone changes (infrequent, big impact)
- users manually changing system time (infrequent, big impact)

and is therefore preferred over time.time when measuring relative times (of a program).

Smaller improvements:
- Remove __init__ with unnecessary instance attribute assignment (time to load the extension itself is now representative due to explicit start() call)
- Use __slots__ for lower memory consumption of class instance(s)
- Simplify stop(), reducing the amount of checks, instance attribute lookups and variable assignments (performance nits)
- Remove, by definition, the need for the assert statement